### PR TITLE
add smart visio conversion script

### DIFF
--- a/Visio/convert/convert-smart.bat
+++ b/Visio/convert/convert-smart.bat
@@ -1,0 +1,1 @@
+PowerShell.exe -ExecutionPolicy Bypass -File convert-smart.ps1

--- a/Visio/convert/convert-smart.ps1
+++ b/Visio/convert/convert-smart.ps1
@@ -1,0 +1,10 @@
+﻿Foreach ($visioFile in Get-ChildItem *.vsdx) {
+    $figuresPath = Resolve-Path "..\"
+    $pdfFilePath = "$figuresPath\$($visioFile.Name.TrimEnd('vsdx'))pdf"
+    if ((-not (Test-Path $pdfFilePath)) -or ((Get-Item $pdfFilePath).LastWriteTime -lt ($visioFile.LastWriteTime))) {
+        Write-Host "converting $($visioFile.Name)"
+        cscript convert.vbs $visioFile.FullName
+    }
+    
+}
+mv *.pdf ../ -Force


### PR DESCRIPTION
add visio conversion script that only converts if the pdf is out-of-date or non-existent

Windows does not allow running unsigned powershell scripts by default. Ideally convert-smart-ps1. should be signed, but we can bypass this requirement, by launching a powershell instance that bypasses execution policies.
